### PR TITLE
Add installation and setup machinery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-# tripleo-quickstart
+tripleo-quickstart
+==================
 
 One of the barriers to entry for trying out TripleO and its
 derivatives has been the relative difficulty in getting an
@@ -11,35 +12,35 @@ with CentOS 7 installed, and able to be ssh'd to without password from
 the machine running ansible.
 
 The defaults are meant to "just work", so assuming you
-have ansible 2.0 installed it is as easy as:
+have Ansible 2.0 installed it is as easy as::
 
-```bash
     export TEST_MACHINE='my_test_machine.example.com'
     ansible-playbook playbooks/quickstart.yml
-```
 
 The playbook will output a debug message at the end with instructions
 to access the deployed undercloud.
 
-If you need to install ansible 2.0, this is what I used in testing:
-
-```bash
-    git clone https://github.com/ansible/ansible.git
-    cd ansible
-    git checkout v2.0.0-0.6.rc1
-    git submodule update --init --recursive
-    virtualenv .venv --system-site-packages
-    source .venv/bin/activate
-```
-
-## Documentation
+Documentation
+=============
 
 More in-depth documentation is a work in progress. Patches welcome!
 
-### Author
+To install ``tripleo-quickstart``::
+
+    pip install git+https://github.com/trown/tripleo-quickstart.git@master#egg=tripleo-quickstart
+    # tripleo-quickstart requires Ansible 2.0
+    pip install git+https://github.com/ansible/ansible.git@v2.0.0-0.6.rc1#egg=ansible
+
+Playbooks will be located in either ``/usr/local/share/tripleo-quickstart`` or
+in ``$VIRTUAL_ENV/usr/local/share/tripleo-quickstart`` if you have installed in
+a virtual environment.
+
+Author
+======
 John Trowbridge
 
-### Copyright
+Copyright
+=========
 Copyright 2015 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+# Attempt to load custom modules whether it's installed system-wide or from a virtual environment
+library = /usr/lib/python2.7/site-packages/tripleo-quickstart/playbooks/library:$VIRTUAL_ENV/lib/python2.7/site-packages/tripleo-quickstart/playbooks/library:playbooks/library

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pbr>=1.6
+# This doesn't really work due to:
+# https://bugs.launchpad.net/pbr/+bug/1373623
+git+https://github.com/ansible/ansible.git@v2.0.0-0.6.rc1#egg=ansible

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,31 @@
+[metadata]
+name = tripleo-quickstart
+summary = tripleo-quickstart - Making it easy to get started with tripleo
+description-file =
+    README.rst
+author = John Trowbridge
+author-email = jtrowbri@redhat.com
+home-page = https://github.com/trown/tripleo-quickstart
+classifier =
+  License :: OSI Approved :: Apache Software License
+  Development Status :: 4 - Beta
+  Intended Audience :: Developers
+  Intended Audience :: System Administrators
+  Intended Audience :: Information Technology
+  Topic :: Utilities
+
+[global]
+setup-hooks =
+    pbr.hooks.setup_hook
+
+[files]
+data_files =
+    usr/local/share/tripleo-quickstart = ansible.cfg
+    usr/local/share/tripleo-quickstart/playbooks = playbooks/*
+
+[wheel]
+universal = 1
+
+[pbr]
+skip_authors = True
+skip_changelog = True

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+#   Copyright Red Hat, Inc. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+# ansible-lint is not yet compatible with 2.0
+ansible<2.0
+ansible-lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+minversion = 1.6
+envlist = py27
+skipdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+deps = -r{toxinidir}/test-requirements.txt
+
+[testenv:ansible-lint]
+whitelist_externals = bash
+commands = bash -c "for file in $(ls {toxinidir}/playbooks/*.yml); do ansible-lint $file; done"


### PR DESCRIPTION
So now you can install tripleo-quickstart with:

    pip install git+https://github.com/trown/tripleo-quickstart.git@master#egg=tripleo-quickstart

and run ansible-lint with:

    tox -e ansible-lint

Also gave easier instructions to setup Ansible, it looks like pbr doesn't handle it being in the requirements.txt due to a bug (comments inline)