### PR TITLE
Do not tear down when libvirt is down

### DIFF
--- a/playbooks/roles/libvirt/teardown/check/tasks/main.yml
+++ b/playbooks/roles/libvirt/teardown/check/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: check if libvirt is running
+  shell: rpm -qa libvirt && systemctl status libvirtd
+  changed_when: false
+  failed_when: false
+  register: libvirt_check

--- a/playbooks/roles/libvirt/teardown/meta/main.yml
+++ b/playbooks/roles/libvirt/teardown/meta/main.yml
@@ -1,6 +1,9 @@
 ---
 dependencies:
   - { role: libvirt }
-  - { role: teardown/networks, ansible_user: root }
-  - { role: teardown/nodes, ansible_user: root }
+  - { role: teardown/check, ansible_user: root }
+  - { role: teardown/networks, ansible_user: root,
+      when: "libvirt_check.rc == 0" }
+  - { role: teardown/nodes, ansible_user: root,
+      when: "libvirt_check.rc == 0" }
   - { role: teardown/user, ansible_user: root }


### PR DESCRIPTION
When libvirtd is not installed and is not running, it make no sense
tear down libvirt resources