### PR TITLE
make it ignore both system hosts and ansible.cfg

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -8,5 +8,8 @@ pip install git+https://github.com/trown/tripleo-quickstart.git@master#egg=tripl
 # tripleo-quickstart requires Ansible 2.0
 pip install git+https://github.com/ansible/ansible.git@v2.0.0-0.6.rc1#egg=ansible
 
+export ANSIBLE_CONFIG=.quickstart/usr/local/share/tripleo-quickstart/ansible.cfg
+export ANSIBLE_INVENTORY=.quickstart/hosts
+
 RELEASE=${1:-liberty}
 ansible-playbook -vv .quickstart/usr/local/share/tripleo-quickstart/playbooks/quickstart-$RELEASE.yml


### PR DESCRIPTION
If you have a /etc/hosts set up some non trivial error appears 
This change makes it ignore it and use the provided config and hosts