### PR TITLE
Upgrade pip in the virtualenv

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -4,6 +4,7 @@ set -ex
 
 virtualenv .quickstart --system-site-packages
 source .quickstart/bin/activate
+pip install --upgrade pip
 pip install git+https://github.com/trown/tripleo-quickstart.git@master#egg=tripleo-quickstart
 # tripleo-quickstart requires Ansible 2.0
 pip install git+https://github.com/ansible/ansible.git@v2.0.0-0.6.rc1#egg=ansible


### PR DESCRIPTION
This prevents the script from crashing if the workstation's version of pip is less than 7.