### PR TITLE
Force installation of Python packages

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -4,10 +4,10 @@ set -ex
 
 virtualenv .quickstart --system-site-packages
 source .quickstart/bin/activate
-pip install --upgrade pip
+pip install -I pbr
 pip install git+https://github.com/trown/tripleo-quickstart.git@master#egg=tripleo-quickstart
 # tripleo-quickstart requires Ansible 2.0
-pip install git+https://github.com/ansible/ansible.git@v2.0.0-0.6.rc1#egg=ansible
+pip install -I git+https://github.com/ansible/ansible.git@v2.0.0-0.6.rc1#egg=ansible
 
 export ANSIBLE_CONFIG=.quickstart/usr/local/share/tripleo-quickstart/ansible.cfg
 export ANSIBLE_INVENTORY=.quickstart/hosts


### PR DESCRIPTION
System-wide installations of pbr and ansible can prevent modern-enough ones from being installed, causing errors later on.

Upgrading pip wasn't actually helping, so this commit removes that line.